### PR TITLE
[FIX] fixes issues with multi worker

### DIFF
--- a/access_roles/models/button_registry.py
+++ b/access_roles/models/button_registry.py
@@ -44,6 +44,7 @@ class ButtonRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'button_registry_rebuild'):
             self.get_all_buttons()
+            self.env.flush_all()
         return True
 
     def get_all_buttons(self):

--- a/access_roles/models/filter_registry.py
+++ b/access_roles/models/filter_registry.py
@@ -43,6 +43,7 @@ class FilterRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'filter_registry_rebuild'):
             self.get_all_filters()
+            self.env.flush_all()
         return True
 
     def _get_filter_elements_from_arch(self, arch):

--- a/access_roles/models/groupby_registry.py
+++ b/access_roles/models/groupby_registry.py
@@ -43,6 +43,7 @@ class GroupByRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'groupby_registry_rebuild'):
             self.get_all_groupby()
+            self.env.flush_all()
         return True
 
     def _extract_groupby_attributes(self, filter_tag):

--- a/access_roles/models/tab_registry.py
+++ b/access_roles/models/tab_registry.py
@@ -40,6 +40,7 @@ class TabRegistry(models.Model):
         super()._register_hook()
         if run_once(self.env.cr, 'tab_registry_rebuild'):
             self.get_all_tabs()
+            self.env.flush_all()
         return True
 
     def get_all_tabs(self):


### PR DESCRIPTION
This fixes serialization errors when multiple worker are trying to populate the registry tables. To prevent concurrent updates, we use a pg_try_advisory_xact_lock call to check if another worker is already processing the data. If the lock is already held, other workers just skip the registry population.